### PR TITLE
feat: optimize notes format for GPS and ELIoT services

### DIFF
--- a/lib/processors/ELIoTRechargeProcessor.js
+++ b/lib/processors/ELIoTRechargeProcessor.js
@@ -668,10 +668,20 @@ class ELIoTRechargeProcessor extends BaseRechargeProcessor {
             else estadoRecargas = 'FALLAS';
         }
 
-        return `[ELIOT-AUTO v2.0] VENCIDOS: ${totalVencidos} (Recargados: ${recargasExitosas}/${recargasIntentadas} ${estadoRecargas}) | ` +
-               `POR_VENCER: ${totalPorVencer} | AHORRO_INMEDIATO: ${noRecargadosReportando} | ` +
-               `EFICIENCIA: ${ahorroPotencialPorcentaje.toFixed(1)}% | ` +
-               `INVERSION: $${inversionRealizada} | AHORRO_POTENCIAL: $${inversionEvitada}`;
+        // Formato base: VENCIDOS y POR_VENCER siempre
+        let note = `[ELIOT-AUTO v2.0] VENCIDOS: ${totalVencidos} | POR_VENCER: ${totalPorVencer}`;
+
+        // REPORTANDO: solo si es mayor a 0 (dispositivos que estaban reportando y se ahorraron)
+        if (noRecargadosReportando > 0) {
+            note += ` | REPORTANDO: ${noRecargadosReportando} ahorrados`;
+        }
+
+        // RESULTADO: siempre mostrar con formato [XXX/YYY] con ceros a la izquierda
+        const exitosasFormatted = String(recargasExitosas).padStart(3, '0');
+        const intentadasFormatted = String(recargasIntentadas).padStart(3, '0');
+        note += ` | RESULTADO: [${exitosasFormatted}/${intentadasFormatted}]`;
+
+        return note;
     }
 
     generateOptimizedELIoTDetailNote(analyticsData, currentIndex, totalToRecharge) {

--- a/lib/processors/GPSRechargeProcessor.js
+++ b/lib/processors/GPSRechargeProcessor.js
@@ -1340,9 +1340,20 @@ ${avgProcessingTime > 10000 ? '🐌 Procesamiento lento detectado.' : ''}`,
             ahorroInmediato, totalCandidatos, eficiencia
         } = analyticsData;
 
-        return `[GPS-AUTO v2.2] VENCIDOS: ${vencidos} | POR_VENCER: ${porVencer} ${porVencer > 0 ? '(Preventivo)' : ''} | ` +
-               `REPORTANDO: ${ahorroInmediato} | EXITOSAS: ${recargasExitosas}/${recargasIntentadas} de ${totalCandidatos} candidatos | ` +
-               `EFICIENCIA: ${eficiencia.toFixed(1)}%`;
+        // Formato base: VENCIDOS y POR_VENCER siempre
+        let note = `[GPS-AUTO v2.2] VENCIDOS: ${vencidos} | POR_VENCER: ${porVencer}`;
+
+        // REPORTANDO: solo si es mayor a 0
+        if (ahorroInmediato > 0) {
+            note += ` | REPORTANDO: ${ahorroInmediato} ahorrados`;
+        }
+
+        // RESULTADO: siempre mostrar con formato [XXX/YYY] con ceros a la izquierda
+        const exitosasFormatted = String(recargasExitosas).padStart(3, '0');
+        const intentadasFormatted = String(recargasIntentadas).padStart(3, '0');
+        note += ` | RESULTADO: [${exitosasFormatted}/${intentadasFormatted}]`;
+
+        return note;
     }
 
     /**


### PR DESCRIPTION
- Remove redundant efficiency percentages and candidate counts
- Show REPORTANDO only when > 0 (devices that were saved)
- Format RESULTADO as [XXX/YYY] with zero-padding for consistency
- Cleaner, more focused notes without business jargon
- Applied same format pattern to both GPS and ELIoT services

🤖 Generated with [Claude Code](https://claude.ai/code)